### PR TITLE
add HOST env

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -1,9 +1,6 @@
-name: Docker Compose Build
+name: Docker Build
 
-on:
-  push:
-    branches:
-      - master
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Run docker build
-        run: docker build -t vulcanize/postgraphile .
+        run: make docker-build
       - name: Push to Docker Hub
         uses: docker/build-push-action@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN npm install -g @graphile/pg-pubsub
 
 EXPOSE 5000
 
+ENV HOST 0.0.0.0
 ENV PORT 5000
 ENV SCHEMA "public,eth"
 ENV PG_USER "vdbm"
@@ -18,6 +19,6 @@ CMD ["/bin/sh", "-c", "postgraphile \
      --plugins @graphile/pg-pubsub --subscriptions --simple-subscriptions \
      --connection postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DATABASE} \
      --port ${PORT} \
-     -n 0.0.0.0 \
+     -n ${HOST} \
      --schema ${SCHEMA} \
      --append-plugins postgraphile-plugin-connection-filter"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+## Build docker image
+.PHONY: docker-build
+docker-build:
+	docker build -t vulcanize/postgraphile .

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ docker build -t vulcanize/postgraphile .
 
 | Name        | Default Value      | Comment                     |
 |-------------|--------------------|-----------------------------|
+| HOST        | 0.0.0.0            | Postgraphile host           |
 | PORT        | 5000               | Postgraphile port           |
 | SCHEMA      | public,eth         | Postgresql schema to expose |
 | PG_USER     | vdbm               | Postgresql user             |


### PR DESCRIPTION
Add a simple _HOST_ env to the docker file. This allows setting the ip which postgraphile will bind to when running container networking in _host_ mode.